### PR TITLE
Feature/user types

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ The `User` entity attached to the `Member` should have a custom value for `type`
 should be populated accordingly. Leave `entities` as a blank array if the Member
 should only be allowed to log in and view locked content.
 
+The `Member` entity is intended to be separate from the `User` entity as far as
+UI goes. There should be entirely separate routes (ie. `member_index`,
+`member_create`, `member_edit`, `member_delete`, etc.). `User` entities with
+custom `type` values will be excluded from the regular `User` routes.
+
 ## User Type Forms
 
 Create a `MemberUserType` form for handling `User` data under the `Member`:

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ that aren't represented in the `User` entity (eg. `phone`).
 
 The `User` entity attached to the `Member` should have a custom value for `type`
 (recommendend to use the value of `Member::class`) and the value for `entities`
-should be populated accordingly. Leave `entities` as a blank array if the Member
+should be populated accordingly. Set `entities` as a blank array if the Member
 should only be allowed to log in and view locked content.
 
 The `Member` entity is intended to be separate from the `User` entity as far as
@@ -199,7 +199,7 @@ $member = new Member();
 $member->setUser($user);
 ```
 
-Then you can create a custom `ArticleVoter` will logic like the following:
+Then you can create a custom `ArticleVoter` with logic like the following:
 
 ```php
 protected function canEdit(Article $article, User $loggedIn)

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Utilizing voter constants in a template:
 {% endif %}
 ```
 
-## User Permissions
+## Admin Permissions
 
-Editing a non-developer user will show a selection of Permissions. To add to this
+Editing an admin user will show a selection of Permissions. To add to this
 selection, create a service that implements `OHMedia\SecurityBundle\Service\EntityChoiceInterface`.
 
 You may need to manually tag your service as `oh_media_security.entity_choice`.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,10 @@ services:
         tags: ["container.service_subscriber", "controller.service_arguments"]
         autowire: true
 
+    OHMedia\SecurityBundle\Controller\ProfileController:
+        tags: ["container.service_subscriber", "controller.service_arguments"]
+        autowire: true
+
     OHMedia\SecurityBundle\Controller\UserController:
         tags: ["container.service_subscriber", "controller.service_arguments"]
         autowire: true
@@ -28,6 +32,10 @@ services:
         arguments: ["@oh_media_security.entity_choice_manager", "%oh_media_timezone.timezone%"]
         tags: ["form.type"]
 
+    OHMedia\SecurityBundle\Form\ProfileType:
+        arguments: ["%oh_media_timezone.timezone%"]
+        tags: ["form.type"]
+
     OHMedia\SecurityBundle\Repository\UserRepository:
         autowire: true
         tags: ["doctrine.repository_service"]
@@ -42,3 +50,15 @@ services:
     OHMedia\SecurityBundle\Twig\EntityChoiceExtension:
         autowire: true
         tags: ["twig.extension"]
+
+    OHMedia\SecurityBundle\Service\UserLifecycle:
+        autowire: true
+        tags:
+            -
+                name: 'doctrine.orm.entity_listener'
+                event: 'preUpdate'
+                entity: 'OHMedia\SecurityBundle\Entity\User'
+            -
+                name: 'doctrine.orm.entity_listener'
+                event: 'postUpdate'
+                entity: 'OHMedia\SecurityBundle\Entity\User'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -56,6 +56,10 @@ services:
         tags:
             -
                 name: 'doctrine.orm.entity_listener'
+                event: 'prePersist'
+                entity: 'OHMedia\SecurityBundle\Entity\User'
+            -
+                name: 'doctrine.orm.entity_listener'
                 event: 'preUpdate'
                 entity: 'OHMedia\SecurityBundle\Entity\User'
             -

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -41,8 +41,6 @@ class CreateUserCommand extends Command
             return Command::INVALID;
         }
 
-        $developer = $io->confirm('Flag this user as a developer');
-
         $user = new User();
 
         $hashedPassword = $this->passwordHasher->hashPassword(
@@ -53,7 +51,7 @@ class CreateUserCommand extends Command
         $user
             ->setEmail($email)
             ->setPassword($hashedPassword)
-            ->setDeveloper($developer)
+            ->setType(User::TYPE_DEVELOPER)
             ->setEnabled(true)
         ;
 

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -34,9 +34,7 @@ class PasswordController extends AbstractController
         if ($loggedIn = $this->getUser()) {
             $this->addFlash('warning', 'You are already logged in and can change your password below.');
 
-            return $this->redirectToRoute('user_edit', [
-                'id' => $loggedIn->getId(),
-            ]);
+            return $this->redirectToRoute('user_profile');
         }
 
         $formBuilder = $this->createFormBuilder(null, [

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -46,7 +46,7 @@ class ProfileController extends AbstractController
                     $user->setPassword($hashedPassword);
                 }
 
-                $this->userRepository->save($user, true);
+                $userRepository->save($user, true);
 
                 if ($user->shouldSendVerifyEmail()) {
                     $this->addFlash('notice', 'Changes to your profile were saved successfully. The new email address will need to be verified before that change takes effect.');

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -4,6 +4,7 @@ namespace OHMedia\SecurityBundle\Controller;
 
 use OHMedia\BackendBundle\Routing\Attribute\Admin;
 use OHMedia\EmailBundle\Repository\EmailRepository;
+use OHMedia\SecurityBundle\Form\ProfileType;
 use OHMedia\SecurityBundle\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -13,7 +14,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Admin]
-class UserController extends AbstractController
+class ProfileController extends AbstractController
 {
     #[Route('/profile', name: 'user_profile', methods: ['GET', 'POST'])]
     public function __invoke(

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -3,14 +3,12 @@
 namespace OHMedia\SecurityBundle\Controller;
 
 use OHMedia\BackendBundle\Routing\Attribute\Admin;
-use OHMedia\EmailBundle\Repository\EmailRepository;
 use OHMedia\SecurityBundle\Form\ProfileType;
 use OHMedia\SecurityBundle\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Admin]
@@ -18,9 +16,7 @@ class ProfileController extends AbstractController
 {
     #[Route('/profile', name: 'user_profile', methods: ['GET', 'POST'])]
     public function __invoke(
-        EmailRepository $emailRepository,
         Request $request,
-        UserPasswordHasherInterface $passwordHasher,
         UserRepository $userRepository,
     ): Response {
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
@@ -35,17 +31,6 @@ class ProfileController extends AbstractController
 
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
-                $password = $form->get('password')->getData();
-
-                if ($password) {
-                    $hashedPassword = $passwordHasher->hashPassword(
-                        $user,
-                        $password
-                    );
-
-                    $user->setPassword($hashedPassword);
-                }
-
                 $userRepository->save($user, true);
 
                 if ($user->shouldSendVerifyEmail()) {

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace OHMedia\SecurityBundle\Controller;
+
+use OHMedia\BackendBundle\Routing\Attribute\Admin;
+use OHMedia\EmailBundle\Repository\EmailRepository;
+use OHMedia\SecurityBundle\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Admin]
+class UserController extends AbstractController
+{
+    #[Route('/profile', name: 'user_profile', methods: ['GET', 'POST'])]
+    public function __invoke(
+        EmailRepository $emailRepository,
+        Request $request,
+        UserPasswordHasherInterface $passwordHasher,
+        UserRepository $userRepository,
+    ): Response {
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
+
+        $user = $this->getUser();
+
+        $form = $this->createForm(ProfileType::class, $user);
+
+        $form->add('submit', SubmitType::class);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            if ($form->isValid()) {
+                $password = $form->get('password')->getData();
+
+                if ($password) {
+                    $hashedPassword = $passwordHasher->hashPassword(
+                        $user,
+                        $password
+                    );
+
+                    $user->setPassword($hashedPassword);
+                }
+
+                $this->userRepository->save($user, true);
+
+                if ($user->shouldSendVerifyEmail()) {
+                    $this->addFlash('notice', 'Changes to your profile were saved successfully. The new email address will need to be verified before that change takes effect.');
+                } else {
+                    $this->addFlash('notice', 'Changes to your profile were saved successfully.');
+                }
+
+                return $this->redirectToRoute('user_profile');
+            }
+
+            $this->addFlash('error', 'There are some errors in the form below.');
+        }
+
+        return $this->render('@OHMediaSecurity/user/user_profile.html.twig', [
+            'user' => $user,
+            'form' => $form->createView(),
+            'form_title' => 'Profile',
+        ]);
+    }
+}

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -41,8 +41,9 @@ class UserController extends AbstractController
 
         $loggedIn = $this->getUser();
 
-        if (!$loggedIn->isDeveloper()) {
-            $qb->where('(u.developer IS NULL OR u.developer = 0)');
+        if (!$loggedIn->isTypeDeveloper()) {
+            $qb->where('(u.type <> :developer)')
+                ->setParameter('developer', User::TYPE_DEVELOPER);
         }
 
         return $this->render('@OHMediaSecurity/user/user_index.html.twig', [

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -4,7 +4,6 @@ namespace OHMedia\SecurityBundle\Controller;
 
 use OHMedia\BackendBundle\Routing\Attribute\Admin;
 use OHMedia\BootstrapBundle\Service\Paginator;
-use OHMedia\EmailBundle\Repository\EmailRepository;
 use OHMedia\SecurityBundle\Entity\User;
 use OHMedia\SecurityBundle\Form\UserType;
 use OHMedia\SecurityBundle\Repository\UserRepository;
@@ -14,7 +13,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Admin]
@@ -65,10 +63,8 @@ class UserController extends AbstractController
     }
 
     #[Route('/user/create', name: 'user_create', methods: ['GET', 'POST'])]
-    public function create(
-        Request $request,
-        UserPasswordHasherInterface $passwordHasher,
-    ): Response {
+    public function create(Request $request): Response
+    {
         $user = new User();
 
         $this->denyAccessUnlessGranted(
@@ -87,13 +83,6 @@ class UserController extends AbstractController
 
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
-                $hashedPassword = $passwordHasher->hashPassword(
-                    $user,
-                    $form->get('password')->getData()
-                );
-
-                $user->setPassword($hashedPassword);
-
                 $this->userRepository->save($user, true);
 
                 $this->addFlash('notice', 'Changes to the user were saved successfully.');
@@ -112,12 +101,8 @@ class UserController extends AbstractController
     }
 
     #[Route('/user/{id}/edit', name: 'user_edit', methods: ['GET', 'POST'])]
-    public function edit(
-        EmailRepository $emailRepository,
-        Request $request,
-        User $user,
-        UserPasswordHasherInterface $passwordHasher,
-    ): Response {
+    public function edit(Request $request, User $user): Response
+    {
         $this->denyAccessUnlessGranted(
             UserVoter::EDIT,
             $user,
@@ -134,17 +119,6 @@ class UserController extends AbstractController
 
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
-                $password = $form->get('password')->getData();
-
-                if ($password) {
-                    $hashedPassword = $passwordHasher->hashPassword(
-                        $user,
-                        $password
-                    );
-
-                    $user->setPassword($hashedPassword);
-                }
-
                 $this->userRepository->save($user, true);
 
                 if ($user->shouldSendVerifyEmail()) {
@@ -167,10 +141,8 @@ class UserController extends AbstractController
     }
 
     #[Route('/user/{id}/delete', name: 'user_delete', methods: ['GET', 'POST'])]
-    public function delete(
-        Request $request,
-        User $user,
-    ): Response {
+    public function delete(Request $request, User $user): Response
+    {
         $this->denyAccessUnlessGranted(
             UserVoter::DELETE,
             $user,

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -46,6 +46,10 @@ class UserController extends AbstractController
                 ->setParameter('developer', User::TYPE_DEVELOPER);
         }
 
+        $qb->addSelect('COALESCE(u.first_name, u.email) AS HIDDEN ord');
+
+        $qb->orderBy('ord', 'ASC');
+
         return $this->render('@OHMediaSecurity/user/user_index.html.twig', [
             'pagination' => $paginator->paginate($qb, 20),
             'new_user' => new User(),

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -42,7 +42,7 @@ class UserController extends AbstractController
         $loggedIn = $this->getUser();
 
         if (!$loggedIn->isTypeDeveloper()) {
-            $qb->where('(u.type <> :developer)')
+            $qb->where('u.type <> :developer')
                 ->setParameter('developer', User::TYPE_DEVELOPER);
         }
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -4,22 +4,18 @@ namespace OHMedia\SecurityBundle\Controller;
 
 use OHMedia\BackendBundle\Routing\Attribute\Admin;
 use OHMedia\BootstrapBundle\Service\Paginator;
-use OHMedia\EmailBundle\Entity\Email;
 use OHMedia\EmailBundle\Repository\EmailRepository;
-use OHMedia\EmailBundle\Util\EmailAddress;
 use OHMedia\SecurityBundle\Entity\User;
 use OHMedia\SecurityBundle\Form\UserType;
 use OHMedia\SecurityBundle\Repository\UserRepository;
 use OHMedia\SecurityBundle\Security\Voter\UserVoter;
 use OHMedia\UtilityBundle\Form\DeleteType;
-use OHMedia\UtilityBundle\Util\RandomString;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[Admin]
 class UserController extends AbstractController
@@ -112,25 +108,7 @@ class UserController extends AbstractController
             'user' => $user,
             'form' => $form->createView(),
             'form_title' => 'Create User',
-            'is_profile' => false,
         ]);
-    }
-
-    #[Route('/profile', name: 'user_profile', methods: ['GET', 'POST'])]
-    public function profile(
-        EmailRepository $emailRepository,
-        Request $request,
-        UserPasswordHasherInterface $passwordHasher,
-    ): Response {
-        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
-
-        return $this->editForm(
-            $emailRepository,
-            $request,
-            $this->getUser(),
-            $passwordHasher,
-            true
-        );
     }
 
     #[Route('/user/{id}/edit', name: 'user_edit', methods: ['GET', 'POST'])]
@@ -146,52 +124,16 @@ class UserController extends AbstractController
             'You cannot edit this user.'
         );
 
-        return $this->editForm(
-            $emailRepository,
-            $request,
-            $user,
-            $passwordHasher,
-            false
-        );
-    }
-
-    private function editForm(
-        EmailRepository $emailRepository,
-        Request $request,
-        User $user,
-        UserPasswordHasherInterface $passwordHasher,
-        bool $isProfile
-    ): Response {
         $form = $this->createForm(UserType::class, $user, [
             'logged_in' => $this->getUser(),
         ]);
 
         $form->add('submit', SubmitType::class);
 
-        $oldEmail = $user->getEmail();
-
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
-                $newEmail = $form->get('email')->getData();
-
-                $verifyEmail = $oldEmail !== $newEmail;
-
-                if ($verifyEmail) {
-                    $token = RandomString::get(50, function ($token) {
-                        return !$this->userRepository->findOneBy([
-                            'verify_token' => $token,
-                        ]);
-                    });
-
-                    $user
-                        ->setEmail($oldEmail)
-                        ->setVerifyToken($token)
-                        ->setVerifyEmail($newEmail)
-                    ;
-                }
-
                 $password = $form->get('password')->getData();
 
                 if ($password) {
@@ -205,19 +147,13 @@ class UserController extends AbstractController
 
                 $this->userRepository->save($user, true);
 
-                $noun = $isProfile ? 'your profile' : 'the user';
-
-                if ($verifyEmail) {
-                    $this->addFlash('notice', "Changes to $noun were saved successfully. The new email address will need to be verified before that change takes effect.");
-
-                    $this->createVerificationEmail($emailRepository, $user);
+                if ($user->shouldSendVerifyEmail()) {
+                    $this->addFlash('notice', 'Changes to the user were saved successfully. The new email address will need to be verified before that change takes effect.');
                 } else {
-                    $this->addFlash('notice', "Changes to $noun were saved successfully.");
+                    $this->addFlash('notice', 'Changes to the user were saved successfully.');
                 }
 
-                return $isProfile
-                    ? $this->redirectToRoute('user_profile')
-                    : $this->redirectToRoute('user_index');
+                return $this->redirectToRoute('user_index');
             }
 
             $this->addFlash('error', 'There are some errors in the form below.');
@@ -226,29 +162,8 @@ class UserController extends AbstractController
         return $this->render('@OHMediaSecurity/user/user_form.html.twig', [
             'user' => $user,
             'form' => $form->createView(),
-            'form_title' => $isProfile ? 'Profile' : 'Edit User',
-            'is_profile' => $isProfile,
+            'form_title' => 'Edit User',
         ]);
-    }
-
-    private function createVerificationEmail(EmailRepository $emailRepository, User $user)
-    {
-        $url = $this->generateUrl('user_verify_email', [
-            'token' => $user->getVerifyToken(),
-        ], UrlGeneratorInterface::ABSOLUTE_URL);
-
-        $to = new EmailAddress($user->getVerifyEmail(), $user->getFullName());
-
-        $email = (new Email())
-            ->setSubject('Verify Email Address')
-            ->setTemplate('@OHMediaSecurity/email/verification_email.html.twig', [
-                'user' => $user,
-                'url' => $url,
-            ])
-            ->setTo($to)
-        ;
-
-        $emailRepository->save($email, true);
     }
 
     #[Route('/user/{id}/delete', name: 'user_delete', methods: ['GET', 'POST'])]

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -41,10 +41,17 @@ class UserController extends AbstractController
 
         $loggedIn = $this->getUser();
 
-        if (!$loggedIn->isTypeDeveloper()) {
-            $qb->where('u.type <> :developer')
-                ->setParameter('developer', User::TYPE_DEVELOPER);
+        $types = [
+            User::TYPE_SUPER,
+            User::TYPE_ADMIN,
+        ];
+
+        if ($loggedIn->isTypeDeveloper()) {
+            $types[] = User::TYPE_DEVELOPER;
         }
+
+        $qb->where('u.type IN (:types)')
+            ->setParameter('types', $types);
 
         $qb->addSelect('COALESCE(u.first_name, u.email) AS HIDDEN ord');
 

--- a/src/Controller/VerificationController.php
+++ b/src/Controller/VerificationController.php
@@ -3,10 +3,8 @@
 namespace OHMedia\SecurityBundle\Controller;
 
 use OHMedia\BackendBundle\Routing\Attribute\Admin;
-use OHMedia\SecurityBundle\Entity\User;
 use OHMedia\SecurityBundle\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -29,7 +27,7 @@ class VerificationController extends AbstractController
         if (!$user) {
             $this->addFlash('error', 'Invalid verification token.');
 
-            return $this->redirectVerification($loggedIn, $loggedIn);
+            return $this->redirectToRoute('user_profile');
         }
 
         $user
@@ -42,17 +40,6 @@ class VerificationController extends AbstractController
 
         $this->addFlash('notice', 'Your email is verified.');
 
-        return $this->redirectVerification($loggedIn, $user);
-    }
-
-    private function redirectVerification(?User $loggedIn, ?User $redirectUser): RedirectResponse
-    {
-        if ($redirectUser) {
-            return $this->redirectToRoute('user_edit', [
-                'id' => $redirectUser->getId(),
-            ]);
-        } else {
-            return $this->redirectToRoute('user_login');
-        }
+        return $this->redirectToRoute('user_profile');
     }
 }

--- a/src/Controller/VerificationController.php
+++ b/src/Controller/VerificationController.php
@@ -30,11 +30,7 @@ class VerificationController extends AbstractController
             return $this->redirectToRoute('user_profile');
         }
 
-        $user
-            ->setEmail($user->getVerifyEmail())
-            ->setVerifyToken(null)
-            ->setVerifyEmail(null)
-        ;
+        $user->setEmailVerified();
 
         $userRepository->save($user, true);
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -22,6 +22,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public const TYPE_SUPER = 'super';
     public const TYPE_ADMIN = 'admin';
 
+    public const PASSWORD_CHANGE = 'PASSWORD_CHANGE';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -101,6 +103,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function setNewPassword(?string $new_password): static
     {
+        if ($new_password) {
+            $this->password = self::PASSWORD_CHANGE;
+        }
+
         $this->new_password = $new_password;
 
         return $this;
@@ -298,8 +304,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function eraseCredentials(): void
     {
-        // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->new_password = null;
     }
 
     public function getUserIdentifier(): string

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -210,6 +210,37 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->sendVerifyEmail;
     }
 
+    public function doEmailVerification(string $oldEmail, string $newEmail, string $verifyToken): static
+    {
+        $this->sendVerifyEmail = true;
+        $this->email = $oldEmail;
+        $this->verify_email = $newEmail;
+        $this->verify_token = $verifyToken;
+
+        return $this;
+    }
+
+    private bool $emailJustVerified = false;
+
+    public function wasEmailJustVerified(): bool
+    {
+        return $this->emailJustVerified;
+    }
+
+    public function setEmailVerified(): static
+    {
+        if (!$this->verify_email || !$this->verify_token) {
+            throw new \LogicException('The verify email/token is blank.');
+        }
+
+        $this->emailJustVerified = true;
+        $this->email = $this->verify_email;
+        $this->verify_token = null;
+        $this->verify_email = null;
+
+        return $this;
+    }
+
     public function getVerifyEmail(): ?string
     {
         return $this->verify_email;
@@ -217,8 +248,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function setVerifyEmail(?string $verifyEmail): static
     {
-        $this->sendVerifyEmail = $verifyEmail && $verifyEmail !== $this->verify_email;
-
         $this->verify_email = $verifyEmail;
 
         return $this;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -18,6 +18,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     use BlameableEntityTrait;
     use TimezoneUserTrait;
 
+    public const TYPE_DEVELOPER = 'developer';
+    public const TYPE_SUPER = 'super';
+    public const TYPE_ADMIN = 'admin';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -61,6 +65,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column(options: ['default' => false])]
     private ?bool $admin = false;
+
+    #[ORM\Column(length: 255)]
+    private ?string $type = null;
 
     public function __toString(): string
     {
@@ -276,5 +283,37 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->admin = $admin;
 
         return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function isType(string $type): bool
+    {
+        return $type === $this->type;
+    }
+
+    public function isTypeDeveloper(): bool
+    {
+        return $this->isType(static::TYPE_DEVELOPER);
+    }
+
+    public function isTypeSuper(): bool
+    {
+        return $this->isType(static::TYPE_SUPER);
+    }
+
+    public function isTypeAdmin(): bool
+    {
+        return $this->isType(static::TYPE_ADMIN);
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -203,6 +203,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
+    private bool $sendVerifyEmail = false;
+
+    public function shouldSendVerifyEmail(): bool
+    {
+        return $this->sendVerifyEmail;
+    }
+
     public function getVerifyEmail(): ?string
     {
         return $this->verify_email;
@@ -210,6 +217,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function setVerifyEmail(?string $verifyEmail): static
     {
+        $this->sendVerifyEmail = $verifyEmail && $verifyEmail !== $this->verify_email;
+
         $this->verify_email = $verifyEmail;
 
         return $this;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -40,9 +40,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $last_name = null;
 
     #[ORM\Column(nullable: true)]
-    private ?bool $developer = null;
-
-    #[ORM\Column(nullable: true)]
     private ?bool $enabled = null;
 
     #[ORM\Column(length: 50, nullable: true)]
@@ -61,10 +58,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $verify_email = null;
 
     #[ORM\Column]
-    private array $entities = [];
-
-    #[ORM\Column(options: ['default' => false])]
-    private ?bool $admin = false;
+    private array $admin_entities = [];
 
     #[ORM\Column(length: 255)]
     private ?string $type = null;
@@ -149,18 +143,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return implode(' ', $parts);
     }
 
-    public function isDeveloper(): bool
-    {
-        return (bool) $this->developer;
-    }
-
-    public function setDeveloper(?bool $developer): static
-    {
-        $this->developer = $developer;
-
-        return $this;
-    }
-
     public function isEnabled(): ?bool
     {
         return $this->enabled;
@@ -233,14 +215,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function getEntities(): array
+    public function getAdminEntities(): array
     {
-        return $this->entities;
+        return $this->admin_entities;
     }
 
-    public function setEntities(array $entities): static
+    public function setAdminEntities(array $admin_entities): static
     {
-        $this->entities = $entities;
+        $this->admin_entities = $admin_entities;
 
         return $this;
     }
@@ -271,18 +253,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function getUserIdentifier(): string
     {
         return $this->email;
-    }
-
-    public function isAdmin(): ?bool
-    {
-        return $this->admin;
-    }
-
-    public function setAdmin(?bool $admin): static
-    {
-        $this->admin = $admin;
-
-        return $this;
     }
 
     public function getType(): ?string

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -58,7 +58,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $verify_email = null;
 
     #[ORM\Column]
-    private array $admin_entities = [];
+    private array $entities = [];
 
     #[ORM\Column(length: 255)]
     private ?string $type = null;
@@ -215,14 +215,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function getAdminEntities(): array
+    public function getEntities(): array
     {
-        return $this->admin_entities;
+        return $this->entities;
     }
 
-    public function setAdminEntities(array $admin_entities): static
+    public function setEntities(array $entities): static
     {
-        $this->admin_entities = $admin_entities;
+        $this->entities = $entities;
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -92,6 +92,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->getEmail();
     }
 
+    private ?string $new_password = null;
+
+    public function getNewPassword(): ?string
+    {
+        return $this->new_password;
+    }
+
+    public function setNewPassword(?string $new_password): static
+    {
+        $this->new_password = $new_password;
+
+        return $this;
+    }
+
     public function getPassword(): string
     {
         return (string) $this->password;

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -36,14 +36,13 @@ class ProfileType extends AbstractType
                     ? 'New email address awaiting verification: '.$verifyEmail
                     : '',
             ])
-            ->add('password', RepeatedType::class, [
+            ->add('new_password', RepeatedType::class, [
                 'required' => !$user || !$user->getId(),
                 'type' => PasswordType::class,
                 'options' => ['attr' => ['autocomplete' => 'new-password']],
                 'invalid_message' => 'The password fields must match.',
                 'first_options' => ['label' => 'Change Password'],
                 'second_options' => ['label' => 'Repeat Password'],
-                'mapped' => false,
             ])
             ->add('timezone', TimezoneType::class, [
                 'required' => false,

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace OHMedia\SecurityBundle\Form;
+
+use OHMedia\SecurityBundle\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ProfileType extends AbstractType
+{
+    public function __construct(private string $defaultTimezone)
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $user = isset($options['data']) ? $options['data'] : null;
+
+        $verifyEmail = $user ? $user->getVerifyEmail() : null;
+
+        $builder
+            ->add('first_name', TextType::class, [
+                'required' => false,
+            ])
+            ->add('last_name', TextType::class, [
+                'required' => false,
+            ])
+            ->add('email', EmailType::class, [
+                'help' => $verifyEmail
+                    ? 'New email address awaiting verification: '.$verifyEmail
+                    : '',
+            ])
+            ->add('password', RepeatedType::class, [
+                'required' => !$user || !$user->getId(),
+                'type' => PasswordType::class,
+                'options' => ['attr' => ['autocomplete' => 'new-password']],
+                'invalid_message' => 'The password fields must match.',
+                'first_options' => ['label' => 'Change Password'],
+                'second_options' => ['label' => 'Repeat Password'],
+                'mapped' => false,
+            ])
+            ->add('timezone', TimezoneType::class, [
+                'required' => false,
+                'help' => 'The default timezone is '.$this->defaultTimezone.'.',
+                'placeholder' => 'Default',
+                'attr' => [
+                    'class' => 'nice-select2',
+                    'placeholder' => 'Default',
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -78,11 +78,11 @@ class UserType extends AbstractType
             ]);
         }
 
-        if (!$user->isDeveloper() && !$usersMatch) {
-            $builder->add('admin', ChoiceType::class, [
+        if (!$user->isTypeDeveloper() && !$usersMatch) {
+            $builder->add('type', ChoiceType::class, [
                 'choices' => [
-                    'Yes' => true,
-                    'No' => false,
+                    'Super Admin' => User::TYPE_SUPER,
+                    'Admin' => User::TYPE_ADMIN,
                 ],
                 'expanded' => true,
                 'row_attr' => [
@@ -90,13 +90,13 @@ class UserType extends AbstractType
                 ],
             ]);
 
-            $this->addEntitiesField($builder);
+            $this->addAdminEntitiesField($builder);
         }
     }
 
-    private function addEntitiesField(FormBuilderInterface $builder)
+    private function addAdminEntitiesField(FormBuilderInterface $builder)
     {
-        $builder->add('entities', ChoiceType::class, [
+        $builder->add('admin_entities', ChoiceType::class, [
             'label' => 'Permissions',
             'choices' => $this->entityChoiceManager->getEntityChoices(),
             'choice_label' => 'label',
@@ -104,11 +104,11 @@ class UserType extends AbstractType
             'expanded' => true,
             'row_attr' => [
                 'class' => 'fieldset-nostyle',
-                'id' => 'user_entities_container',
+                'id' => 'admin_entities_container',
             ],
         ]);
 
-        $builder->get('entities')
+        $builder->get('admin_entities')
             ->addModelTransformer(new CallbackTransformer(
                 function ($entities) {
                     return $this->entityChoiceManager->transformEntitiesToEntityChoices(...$entities);

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -79,20 +79,15 @@ class UserType extends AbstractType
         }
 
         if (!$user->isTypeDeveloper() && !$usersMatch) {
-            $superTooltip = '<span data-bs-toggle="tooltip" data-bs-title="Access to all backend areas." class="bi bi-info-circle-fill"></span>';
-
-            $adminTooltip = '<span data-bs-toggle="tooltip" data-bs-title="Access to select backend areas." class="bi bi-info-circle-fill"></span>';
-
             $builder->add('type', ChoiceType::class, [
                 'choices' => [
-                    'Super Admin '.$superTooltip => User::TYPE_SUPER,
-                    'Admin '.$adminTooltip => User::TYPE_ADMIN,
+                    'Super Admin' => User::TYPE_SUPER,
+                    'Admin' => User::TYPE_ADMIN,
                 ],
                 'expanded' => true,
                 'row_attr' => [
                     'class' => 'fieldset-nostyle',
                 ],
-                'label_html' => true,
             ]);
 
             $this->addEntitiesField($builder);

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -90,13 +90,13 @@ class UserType extends AbstractType
                 ],
             ]);
 
-            $this->addAdminEntitiesField($builder);
+            $this->addEntitiesField($builder);
         }
     }
 
-    private function addAdminEntitiesField(FormBuilderInterface $builder)
+    private function addEntitiesField(FormBuilderInterface $builder)
     {
-        $builder->add('admin_entities', ChoiceType::class, [
+        $builder->add('entities', ChoiceType::class, [
             'label' => 'Admin Permissions',
             'choices' => $this->entityChoiceManager->getEntityChoices(),
             'choice_label' => 'label',
@@ -104,11 +104,11 @@ class UserType extends AbstractType
             'expanded' => true,
             'row_attr' => [
                 'class' => 'fieldset-nostyle',
-                'id' => 'admin_entities_container',
+                'id' => 'user_entities_container',
             ],
         ]);
 
-        $builder->get('admin_entities')
+        $builder->get('entities')
             ->addModelTransformer(new CallbackTransformer(
                 function ($entities) {
                     return $this->entityChoiceManager->transformEntitiesToEntityChoices(...$entities);

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -79,15 +79,20 @@ class UserType extends AbstractType
         }
 
         if (!$user->isTypeDeveloper() && !$usersMatch) {
+            $superTooltip = '<span data-bs-toggle="tooltip" data-bs-title="Access to all backend areas." class="bi bi-info-circle-fill"></span>';
+
+            $adminTooltip = '<span data-bs-toggle="tooltip" data-bs-title="Access to select backend areas." class="bi bi-info-circle-fill"></span>';
+
             $builder->add('type', ChoiceType::class, [
                 'choices' => [
-                    'Super Admin' => User::TYPE_SUPER,
-                    'Admin' => User::TYPE_ADMIN,
+                    'Super Admin '.$superTooltip => User::TYPE_SUPER,
+                    'Admin '.$adminTooltip => User::TYPE_ADMIN,
                 ],
                 'expanded' => true,
                 'row_attr' => [
                     'class' => 'fieldset-nostyle',
                 ],
+                'label_html' => true,
             ]);
 
             $this->addEntitiesField($builder);

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -97,7 +97,7 @@ class UserType extends AbstractType
     private function addAdminEntitiesField(FormBuilderInterface $builder)
     {
         $builder->add('admin_entities', ChoiceType::class, [
-            'label' => 'Permissions',
+            'label' => 'Admin Permissions',
             'choices' => $this->entityChoiceManager->getEntityChoices(),
             'choice_label' => 'label',
             'multiple' => true,

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -31,6 +31,10 @@ class UserType extends AbstractType
 
         $verifyEmail = $user ? $user->getVerifyEmail() : null;
 
+        $userExists = $user && $user->getId();
+
+        $passwordLabel = $userExists ? 'Change Password' : 'Password';
+
         $builder
             ->add('first_name', TextType::class, [
                 'required' => false,
@@ -43,14 +47,13 @@ class UserType extends AbstractType
                     ? 'New email address awaiting verification: '.$verifyEmail
                     : '',
             ])
-            ->add('password', RepeatedType::class, [
-                'required' => !$user || !$user->getId(),
+            ->add('new_password', RepeatedType::class, [
+                'required' => !$userExists,
                 'type' => PasswordType::class,
                 'options' => ['attr' => ['autocomplete' => 'new-password']],
                 'invalid_message' => 'The password fields must match.',
-                'first_options' => ['label' => 'Password'],
+                'first_options' => ['label' => $passwordLabel],
                 'second_options' => ['label' => 'Repeat Password'],
-                'mapped' => false,
             ])
             ->add('timezone', TimezoneType::class, [
                 'required' => false,

--- a/src/Security/Voter/AbstractEntityVoter.php
+++ b/src/Security/Voter/AbstractEntityVoter.php
@@ -48,7 +48,7 @@ abstract class AbstractEntityVoter extends Voter
         }
 
         if (!$loggedIn->isTypeDeveloper() && !$loggedIn->isTypeSuper()) {
-            if (!in_array($this->getEntityClass(), $loggedIn->getAdminEntities())) {
+            if (!in_array($this->getEntityClass(), $loggedIn->getEntities())) {
                 return false;
             }
         }

--- a/src/Security/Voter/AbstractEntityVoter.php
+++ b/src/Security/Voter/AbstractEntityVoter.php
@@ -47,8 +47,8 @@ abstract class AbstractEntityVoter extends Voter
             return false;
         }
 
-        if (!$loggedIn->isDeveloper() && !$loggedIn->isAdmin()) {
-            if (!in_array($this->getEntityClass(), $loggedIn->getEntities())) {
+        if (!$loggedIn->isTypeDeveloper() && !$loggedIn->isTypeSuper()) {
+            if (!in_array($this->getEntityClass(), $loggedIn->getAdminEntities())) {
                 return false;
             }
         }

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -38,6 +38,10 @@ class UserVoter extends AbstractEntityVoter
 
     protected function canEdit(User $user, User $loggedIn): bool
     {
+        if (!$this->isStockUserType($user)) {
+            return false;
+        }
+
         if ($user->isTypeDeveloper()) {
             // can only be edited by other developer users
             return $loggedIn->isTypeDeveloper();
@@ -48,6 +52,10 @@ class UserVoter extends AbstractEntityVoter
 
     protected function canDelete(User $user, User $loggedIn): bool
     {
+        if (!$this->isStockUserType($user)) {
+            return false;
+        }
+
         if ($user->isTypeDeveloper()) {
             // developer user cannot be deleted
             return false;
@@ -59,5 +67,10 @@ class UserVoter extends AbstractEntityVoter
         }
 
         return $loggedIn->isTypeDeveloper() || $loggedIn->isTypeSuper();
+    }
+
+    private function isStockUserType(User $user)
+    {
+        return $user->isTypeDeveloper() || $user->isTypeSuper() || $user->isTypeAdmin();
     }
 }

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -28,12 +28,12 @@ class UserVoter extends AbstractEntityVoter
 
     protected function canIndex(User $user, User $loggedIn): bool
     {
-        return true;
+        return $loggedIn->isTypeDeveloper() || $loggedIn->isTypeSuper();
     }
 
     protected function canCreate(User $user, User $loggedIn): bool
     {
-        return true;
+        return $loggedIn->isTypeDeveloper() || $loggedIn->isTypeSuper();
     }
 
     protected function canEdit(User $user, User $loggedIn): bool
@@ -43,7 +43,7 @@ class UserVoter extends AbstractEntityVoter
             return $loggedIn->isTypeDeveloper();
         }
 
-        return true;
+        return $loggedIn->isTypeDeveloper() || $loggedIn->isTypeSuper();
     }
 
     protected function canDelete(User $user, User $loggedIn): bool
@@ -54,6 +54,10 @@ class UserVoter extends AbstractEntityVoter
         }
 
         // user cannot delete themselves
-        return $user !== $loggedIn;
+        if ($user === $loggedIn) {
+            return false;
+        }
+
+        return $loggedIn->isTypeDeveloper() || $loggedIn->isTypeSuper();
     }
 }

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -38,9 +38,9 @@ class UserVoter extends AbstractEntityVoter
 
     protected function canEdit(User $user, User $loggedIn): bool
     {
-        if ($user->isDeveloper()) {
+        if ($user->isTypeDeveloper()) {
             // can only be edited by other developer users
-            return $loggedIn->isDeveloper();
+            return $loggedIn->isTypeDeveloper();
         }
 
         return true;
@@ -48,7 +48,7 @@ class UserVoter extends AbstractEntityVoter
 
     protected function canDelete(User $user, User $loggedIn): bool
     {
-        if ($user->isDeveloper()) {
+        if ($user->isTypeDeveloper()) {
             // developer user cannot be deleted
             return false;
         }

--- a/src/Service/UserLifecycle.php
+++ b/src/Service/UserLifecycle.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace OHMedia\SecurityBundle\Service;
+
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use OHMedia\EmailBundle\Entity\Email;
+use OHMedia\EmailBundle\Repository\EmailRepository;
+use OHMedia\EmailBundle\Util\EmailAddress;
+use OHMedia\SecurityBundle\Entity\User;
+use OHMedia\SecurityBundle\Repository\UserRepository;
+use OHMedia\UtilityBundle\Util\RandomString;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class UserLifecycle
+{
+    public function __construct(
+        private EmailRepository $emailRepository,
+        private UrlGeneratorInterface $urlGenerator,
+        private UserRepository $userRepository,
+    ) {
+    }
+
+    public function preUpdate(User $user, PreUpdateEventArgs $event)
+    {
+        $oldEmail = $event->getOldValue('email');
+        $newEmail = $event->getNewValue('email');
+
+        if ($oldEmail !== $newEmail) {
+            $token = RandomString::get(50, function ($token) {
+                return !$this->userRepository->findOneBy([
+                    'verify_token' => $token,
+                ]);
+            });
+
+            $user
+                ->setEmail($oldEmail)
+                ->setVerifyToken($token)
+                ->setVerifyEmail($newEmail)
+            ;
+        }
+    }
+
+    public function postUpdate(User $user, PostUpdateEventArgs $event)
+    {
+        if ($user->shouldSendVerifyEmail()) {
+            $url = $this->urlGenerator->generate('user_verify_email', [
+                'token' => $user->getVerifyToken(),
+            ], UrlGeneratorInterface::ABSOLUTE_URL);
+
+            $to = new EmailAddress($user->getVerifyEmail(), $user->getFullName());
+
+            $email = (new Email())
+                ->setSubject('Verify Email Address')
+                ->setTemplate('@OHMediaSecurity/email/verification_email.html.twig', [
+                    'user' => $user,
+                    'url' => $url,
+                ])
+                ->setTo($to)
+            ;
+
+            $this->emailRepository->save($email, true);
+        }
+    }
+}

--- a/src/Service/UserLifecycle.php
+++ b/src/Service/UserLifecycle.php
@@ -3,6 +3,7 @@
 namespace OHMedia\SecurityBundle\Service;
 
 use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use OHMedia\EmailBundle\Entity\Email;
 use OHMedia\EmailBundle\Repository\EmailRepository;
@@ -78,9 +79,9 @@ class UserLifecycle
     {
         $newPassword = $user->getNewPassword();
 
-        exit($newPassword);
+        $currentPassword = $user->getPassword();
 
-        if (!$newPassword) {
+        if (!$newPassword || User::PASSWORD_CHANGE !== $currentPassword) {
             return;
         }
 

--- a/src/Service/UserLifecycle.php
+++ b/src/Service/UserLifecycle.php
@@ -23,10 +23,25 @@ class UserLifecycle
 
     public function preUpdate(User $user, PreUpdateEventArgs $event)
     {
-        $oldEmail = $event->getOldValue('email');
-        $newEmail = $event->getNewValue('email');
+        if ($event->hasChangedField('verify_token')) {
+            $oldToken = $event->getOldValue('verify_token');
+            $newToken = $event->getNewValue('verify_token');
 
-        if ($oldEmail !== $newEmail) {
+            $emailJustVerified = $oldToken && !$newToken;
+        } else {
+            $emailJustVerified = false;
+        }
+
+        if (!$emailJustVerified && $event->hasChangedField('email')) {
+            $oldEmail = $event->getOldValue('email');
+            $newEmail = $event->getNewValue('email');
+
+            $emailChanged = $oldEmail !== $newEmail;
+        } else {
+            $emailChanged = false;
+        }
+
+        if ($emailChanged) {
             $token = RandomString::get(50, function ($token) {
                 return !$this->userRepository->findOneBy([
                     'verify_token' => $token,

--- a/src/Twig/EntityChoiceExtension.php
+++ b/src/Twig/EntityChoiceExtension.php
@@ -44,7 +44,7 @@ class EntityChoiceExtension extends AbstractExtension
                 'text' => 'Admin',
             ];
 
-            $entityChoices = $this->entityChoiceManager->transformEntitiesToEntityChoices(...$user->getAdminEntities());
+            $entityChoices = $this->entityChoiceManager->transformEntitiesToEntityChoices(...$user->getEntities());
 
             foreach ($entityChoices as $entityChoice) {
                 $badges[] = [

--- a/src/Twig/EntityChoiceExtension.php
+++ b/src/Twig/EntityChoiceExtension.php
@@ -38,7 +38,7 @@ class EntityChoiceExtension extends AbstractExtension
                 'class_name' => 'text-bg-primary',
                 'text' => 'Super Admin',
             ];
-        } else {
+        } elseif ($user->isTypeAdmin()) {
             $badges[] = [
                 'class_name' => 'text-bg-success',
                 'text' => 'Admin',

--- a/src/Twig/EntityChoiceExtension.php
+++ b/src/Twig/EntityChoiceExtension.php
@@ -28,17 +28,22 @@ class EntityChoiceExtension extends AbstractExtension
     {
         $badges = [];
 
-        if ($user->isDeveloper()) {
+        if ($user->isTypeDeveloper()) {
             $badges[] = [
-                'class_name' => 'text-bg-primary',
+                'class_name' => 'text-bg-dark',
                 'text' => 'Developer',
             ];
-        } elseif ($user->isAdmin()) {
+        } elseif ($user->isTypeSuper()) {
+            $badges[] = [
+                'class_name' => 'text-bg-primary',
+                'text' => 'Super Admin',
+            ];
+        } else {
             $badges[] = [
                 'class_name' => 'text-bg-success',
                 'text' => 'Admin',
             ];
-        } else {
+
             $entityChoices = $this->entityChoiceManager->transformEntitiesToEntityChoices(...$user->getEntities());
 
             foreach ($entityChoices as $entityChoice) {

--- a/src/Twig/EntityChoiceExtension.php
+++ b/src/Twig/EntityChoiceExtension.php
@@ -44,7 +44,7 @@ class EntityChoiceExtension extends AbstractExtension
                 'text' => 'Admin',
             ];
 
-            $entityChoices = $this->entityChoiceManager->transformEntitiesToEntityChoices(...$user->getEntities());
+            $entityChoices = $this->entityChoiceManager->transformEntitiesToEntityChoices(...$user->getAdminEntities());
 
             foreach ($entityChoices as $entityChoice) {
                 $badges[] = [

--- a/templates/user/user_form.html.twig
+++ b/templates/user/user_form.html.twig
@@ -14,20 +14,24 @@
 {% endblock %}
 
 {% block javascripts %}
-{% if form.admin is defined %}
+{% if form.type is defined %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   const form = document.querySelector('form[name={{ form.vars.name }}]');
 
-  const adminRadioNodeList = form.elements['{{ form.admin.vars.full_name }}'];
+  const typeRadioNodeList = form.elements['{{ form.type.vars.full_name }}'];
 
-  const userEntitiesContainer = document.getElementById('user_entities_container');
+  const adminEntitiesContainer = document.getElementById('admin_entities_container');
+
+  const userTypeAdmin = {{ constant('OHMedia\\SecurityBundle\\Entity\\User::TYPE_ADMIN')|json_encode|raw }};
 
   function toggleEntities() {
-    userEntitiesContainer.style.display = parseInt(adminRadioNodeList.value) ? 'none' : '';
+    adminEntitiesContainer.style.display = userTypeAdmin === typeRadioNodeList.value
+        ? ''
+        : 'none';
   }
 
-  adminRadioNodeList.forEach((radio) => {
+  typeRadioNodeList.forEach((radio) => {
     radio.addEventListener('change', () => {
       toggleEntities();
     });

--- a/templates/user/user_form.html.twig
+++ b/templates/user/user_form.html.twig
@@ -21,12 +21,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const typeRadioNodeList = form.elements['{{ form.type.vars.full_name }}'];
 
-  const adminEntitiesContainer = document.getElementById('admin_entities_container');
+  const userEntitiesContainer = document.getElementById('user_entities_container');
 
   const userTypeAdmin = {{ constant('OHMedia\\SecurityBundle\\Entity\\User::TYPE_ADMIN')|json_encode|raw }};
 
   function toggleEntities() {
-    adminEntitiesContainer.style.display = userTypeAdmin === typeRadioNodeList.value
+    userEntitiesContainer.style.display = userTypeAdmin === typeRadioNodeList.value
         ? ''
         : 'none';
   }

--- a/templates/user/user_form.html.twig
+++ b/templates/user/user_form.html.twig
@@ -1,16 +1,10 @@
 {% extends '@OHMediaBackend/form.html.twig' %}
 
 {% block breadcrumbs %}
-{% if is_profile %}
-{{ bootstrap_breadcrumbs(
-  bootstrap_breadcrumb(bootstrap_icon('person-fill') ~ ' Profile', 'user_profile'),
-) }}
-{% else %}
 {{ bootstrap_breadcrumbs(
   bootstrap_breadcrumb(bootstrap_icon('lock-fill') ~ ' Users', 'user_index'),
   bootstrap_breadcrumb(user.id ? 'Edit' : 'Create'),
 ) }}
-{% endif %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/user/user_profile.html.twig
+++ b/templates/user/user_profile.html.twig
@@ -1,0 +1,7 @@
+{% extends '@OHMediaBackend/form.html.twig' %}
+
+{% block breadcrumbs %}
+{{ bootstrap_breadcrumbs(
+  bootstrap_breadcrumb(bootstrap_icon('person-fill') ~ ' Profile', 'user_profile'),
+) }}
+{% endblock %}


### PR DESCRIPTION
Replaced `developer` and `admin` boolean properties with a `type` property and constants `TYPE_DEVELOPER`, `TYPE_SUPER`, and `TYPE_ADMIN`. Developer works the same as `developer=1`. Super works the same as `admin=1`. Admin works the same as `admin=0`. The idea being the Super Admin can do all the things, including user stuff, and each Admin can be assigned to one or more areas of the backend.

The `type` field also allows for the addition of custom users without having separate logins.

Added user event listeners for common email verification functionality.

Made it so command line created users are automatically developer type.

Separate files/functionality for `user_profile` route.