### PR TITLE
Password Strength

### DIFF
--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -12,12 +12,15 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
 
 class ProfileType extends AbstractType
 {
     public function __construct(
         #[Autowire('%oh_media_timezone.timezone%')]
-        private string $defaultTimezone
+        private string $defaultTimezone,
+        #[Autowire('%oh_media_security.password_strength%')]
+        private int $passwordStrength,
     ) {
     }
 
@@ -26,6 +29,14 @@ class ProfileType extends AbstractType
         $user = isset($options['data']) ? $options['data'] : null;
 
         $verifyEmail = $user ? $user->getVerifyEmail() : null;
+
+        $passwordConstraints = [];
+
+        if ($this->passwordStrength) {
+            $passwordConstraints[] = new PasswordStrength([
+                'minScore' => $this->passwordStrength,
+            ]);
+        }
 
         $builder
             ->add('first_name', TextType::class, [
@@ -48,6 +59,7 @@ class ProfileType extends AbstractType
                 'invalid_message' => 'The password fields must match.',
                 'first_options' => ['label' => 'Change Password'],
                 'second_options' => ['label' => 'Repeat Password'],
+                'constraints' => $passwordConstraints,
             ])
             ->add('timezone', TimezoneType::class, [
                 'required' => false,

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -16,13 +16,16 @@ use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
 
 class UserType extends AbstractType
 {
     public function __construct(
         private EntityChoiceManager $entityChoiceManager,
         #[Autowire('%oh_media_timezone.timezone%')]
-        private string $defaultTimezone
+        private string $defaultTimezone,
+        #[Autowire('%oh_media_security.password_strength%')]
+        private int $passwordStrength,
     ) {
     }
 
@@ -42,6 +45,12 @@ class UserType extends AbstractType
 
         if (!$userExists) {
             $passwordConstraints[] = new NotBlank();
+        }
+
+        if ($this->passwordStrength) {
+            $passwordConstraints[] = new PasswordStrength([
+                'minScore' => $this->passwordStrength,
+            ]);
         }
 
         $builder

--- a/src/OHMediaSecurityBundle.php
+++ b/src/OHMediaSecurityBundle.php
@@ -26,7 +26,7 @@ class OHMediaSecurityBundle extends AbstractBundle
                 ->integerNode('password_strength')
                     ->min(PasswordStrength::STRENGTH_VERY_WEAK)
                     ->max(PasswordStrength::STRENGTH_VERY_STRONG)
-                    ->defaultValue(PasswordStrength::STRENGTH_MEDIUM)
+                    ->defaultValue(PasswordStrength::STRENGTH_VERY_WEAK)
                 ->end()
             ->end()
         ;

--- a/src/OHMediaSecurityBundle.php
+++ b/src/OHMediaSecurityBundle.php
@@ -4,9 +4,11 @@ namespace OHMedia\SecurityBundle;
 
 use OHMedia\SecurityBundle\DependencyInjection\Compiler\EntityChoicePass;
 use OHMedia\SecurityBundle\Service\EntityChoiceInterface;
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
 
 class OHMediaSecurityBundle extends AbstractBundle
 {
@@ -17,12 +19,29 @@ class OHMediaSecurityBundle extends AbstractBundle
         $container->addCompilerPass(new EntityChoicePass());
     }
 
+    public function configure(DefinitionConfigurator $definition): void
+    {
+        $definition->rootNode()
+            ->children()
+                ->integerNode('password_strength')
+                    ->min(PasswordStrength::STRENGTH_VERY_WEAK)
+                    ->max(PasswordStrength::STRENGTH_VERY_STRONG)
+                    ->defaultValue(PasswordStrength::STRENGTH_MEDIUM)
+                ->end()
+            ->end()
+        ;
+    }
+
     public function loadExtension(
         array $config,
         ContainerConfigurator $containerConfigurator,
         ContainerBuilder $containerBuilder
     ): void {
         $containerConfigurator->import('../config/services.yaml');
+
+        $containerConfigurator->parameters()
+            ->set('oh_media_security.password_strength', $config['password_strength'])
+        ;
 
         $containerBuilder->registerForAutoconfiguration(EntityChoiceInterface::class)
             ->addTag('oh_media_security.entity_choice')


### PR DESCRIPTION
Add configurable PasswordStrength constraints to password fields in user forms.

By default it's 0, meaning not enabled. It can be enabled with values 1-4. The higher the number, the stronger the requirements. Example:

```yaml
# config/packages/oh_media_security.yaml
oh_media_security:
    password_strength: 1

when@prod:
    oh_media_security:
        password_strength: 4
``` 