### PR TITLE
Change already logged in redirect

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -23,7 +23,7 @@ class LoginController extends AbstractController
         if ($this->getUser()) {
             $this->addFlash('warning', 'You are already logged in.');
 
-            return $this->redirectToRoute('user_index');
+            return $this->redirectToRoute('user_profile');
         }
 
         $formBuilder = $this->createFormBuilder(null, [


### PR DESCRIPTION
I noticed this on natureSK where donors get redirected to the user listing when hitting a login link. I think this should redirect to the profile instead since that's the one route that all users should always have access to?