### PR TITLE
Feature/deprecate erase credentials

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -309,9 +309,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
+    #[\Deprecated]
     public function eraseCredentials(): void
     {
         $this->new_password = null;
+    }
+
+    public function __serialize(): array
+    {
+        $this->new_password = null;
+
+        $data = (array) $this;
+        $data["\0".self::class."\0password"] = hash('crc32c', $this->password);
+
+        return $data;
     }
 
     public function getUserIdentifier(): string

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -315,6 +315,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->new_password = null;
     }
 
+    // https://symfony.com/doc/7.4/security.html#understanding-how-users-are-refreshed-from-the-session
     public function __serialize(): array
     {
         $this->new_password = null;


### PR DESCRIPTION
> User Deprecated: Since symfony/security-http 7.3: Implementing "OHMedia\SecurityBundle\Entity\User::eraseCredentials()" is deprecated since Symfony 7.3; add the #[\Deprecated] attribute on the method to signal its either empty or that you moved the logic elsewhere, typically to the "__serialize()" method.

https://symfony.com/doc/7.4/security.html#understanding-how-users-are-refreshed-from-the-session

Previously, `eraseCredentials` was for clearing unhashed passwords. The only unhashed password was the `new_password` field that doesn't get stored in the DB. Now they are recommending to also hash the hashed password in the `__serialize` method so that when the user object is stored in the session, the actual hashed password is not available.